### PR TITLE
Home Page Design Fix

### DIFF
--- a/oauth/components/links-demo.tsx
+++ b/oauth/components/links-demo.tsx
@@ -114,8 +114,8 @@ export const LinksDemo = () => {
             onDelete={() => deleteShortLink(id)}
           />
         ))}
-        {shortLinks.length < 4 &&
-          [...Array(4 - shortLinks.length)].map((_, idx) => (
+        {shortLinks.length < 3 &&
+          [...Array(3 - shortLinks.length)].map((_, idx) => (
             <LinkPlaceholderCard key={idx} />
           ))}
       </motion.ul>


### PR DESCRIPTION
On the landing page the link demo pushed the text "Kickstart your Dub Integration" behind the navbar and made it look this way
![Screenshot_3-9-2024_44444_oauth dub sh](https://github.com/user-attachments/assets/fda44e6b-de93-427e-90ef-c4858d14fd9f)

Fix: I reduced the maximum number of demo cards to be 3 minus the length of the short strings